### PR TITLE
Desaturate Gtk2 sidebar text color

### DIFF
--- a/common/gtk-2.0/apps.rc
+++ b/common/gtk-2.0/apps.rc
@@ -11,7 +11,7 @@ style "dark-sidebar" {
   base[NORMAL] = @dark_sidebar_bg
   base[INSENSITIVE] = @dark_sidebar_bg
 
-  text[NORMAL] = "#BAC3CF"
+  text[NORMAL] = "#CFCFCF"
   text[ACTIVE] = @selected_fg_color
   text[SELECTED] = @selected_fg_color
 }


### PR DESCRIPTION
It seems like there is a forgotten blueish color in Gtk2 sidebar text color. I've created the neutral color by setting HSV saturation to 0.